### PR TITLE
no signature binary to mv reduction

### DIFF
--- a/TOFIX.md
+++ b/TOFIX.md
@@ -100,3 +100,16 @@ an echo message to ensure the slow ones get enough messages.
 
 - **IMPORTANT:** - unsigned leaser messages need to be checked for validated by SM
   - see consinterfacestate.go line 178, // TODO ("check unsigend messages")
+  
+- A consensus algorithm can be used for causal ordering instead of a broadcast algorithm  
+  - Concerning causal ordering and nil decisions:
+    - In this case nil can be decided
+    - When nil is decided, the state machine is responsible for returning a new set of outputs
+  from the HasDecided function. If it does not return any new outputs then the inputs are considered
+  to be consumed. So for example the AssetProposer generates new outputs (have new IDs)
+  with the same value and owner as the consumed inputs, meaning the assets are not lost.
+  **To FIX:** If config.SignCausalAssets is true then this will panic because
+  the new assest are generates without signatures.
+  - **TO ADD:** Currently when using consensus and causal ordered, the statemachine
+  is the same as with the broadcast where only proposals can only contain the values
+  from the proposer, should allow internal signed transactions from multiple proposers.

--- a/bench_example.sh
+++ b/bench_example.sh
@@ -4,8 +4,8 @@ bash ./scripts/setuprpc.sh
 sleep 1
 for file in ./testconfigs/*
 do
-  echo $file
-  ./rpcbench -o $file
+  echo Running $file
+  PRINT_MIN=true ./rpcbench -o $file
 done
 # ./rpcbench -c 1
 # ./scripts/killgo.sh

--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,7 @@ const (
 	UDPMovingAvgWindowSize = 20                                              // how many previous messages are used for tracking the moving average msg send size, which is then used to caluculate how much to sleep to not exceed UDPMaxSendRate
 	TCPDialTimeout         = 3000                                            // time in ms for TCP dial timeout
 
-	DefaultMsgProcesThreads = 20    // number of threads processing messages (deserialization/verification) before passing to the single consensus thread
+	DefaultMsgProcesThreads = 10    // number of threads processing messages (deserialization/verification) before passing to the single consensus thread
 	ConnectRetires          = 10    // number of times to retry TCP connections
 	P2pGraphGenerateRetries = 10000 // number of times to retry building a random connected graph when using static p2p network
 

--- a/consensus/auth/sig/sleep/coin.go
+++ b/consensus/auth/sig/sleep/coin.go
@@ -50,7 +50,7 @@ func NewCoinSleepPriv(n, t int, i sig.PubKeyIndex, stats *sig.SigStats) sig.Priv
 		n:         n,
 		t:         t,
 		Pub:       cp.GetPub(),
-		sharedPub: newSharedPub(stats, t),
+		sharedPub: newSharedPub(cp.GetPub().New, stats, t),
 	}
 	return &coinPriv{
 		SleepPriv: cp.(SleepPriv),

--- a/consensus/auth/sig/sleep/types.go
+++ b/consensus/auth/sig/sleep/types.go
@@ -162,13 +162,18 @@ func (pub *VrfPub) FromPubBytes(b sig.PubKeyBytes) (sig.Pub, error) {
 }
 
 func NewSleepThrshPriv(n, t int, priv sig.Priv, stats *sig.SigStats) (sig.Priv, error) {
-	p := priv
+	p := priv.(SleepPriv)
+	ppub := &partialPub{
+		sleepPub: p.GetPub().(sleepPub),
+		stats:    stats,
+	}
+	p.setPub(ppub)
 	return &Thrsh{
 		n:         n,
 		t:         t,
 		idx:       p.GetPub().GetIndex(),
 		SleepPriv: p.(SleepPriv),
-		sharedPub: newSharedPub(stats, t),
+		sharedPub: newSharedPub(p.GetPub().New, stats, t),
 	}, nil
 }
 

--- a/consensus/channel/csnet/test_structs_test.go
+++ b/consensus/channel/csnet/test_structs_test.go
@@ -64,9 +64,9 @@ func (sc *TestConsItem) GetConsInterfaceItems() *consinterface.ConsInterfaceItem
 func (sc *TestConsItem) GetNextInfo() (prevIdx types.ConsensusIndex, proposer sig.Pub, preDecision []byte, hasInfo bool) {
 	return
 }
-func (sc *TestConsItem) Start()                    {}
-func (sc *TestConsItem) HasStarted() bool          { return true }
-func (sc *TestConsItem) HasReceivedProposal() bool { return false }
+func (sc *TestConsItem) Start()                {}
+func (sc *TestConsItem) HasStarted() bool      { return true }
+func (sc *TestConsItem) HasValidStarted() bool { return false }
 func (sc *TestConsItem) GetProposalIndex() (prevIdx types.ConsensusIndex, ready bool) {
 	return
 }

--- a/consensus/coin/coinfuncs.go
+++ b/consensus/coin/coinfuncs.go
@@ -70,6 +70,8 @@ func GenerateCoinMessageStateInterface(coinType types.CoinType, isMV bool, pid i
 	switch coinType {
 	case types.KnownCoinType:
 		return knowncoin.NewKnownCoinMsgState(isMV, gc)
+	case types.FlipCoinType:
+		return knowncoin.NewFlipCoinMsgState(isMV, gc)
 	case types.StrongCoin1Type:
 		return strongcoin1.NewStrongCoin1MsgState(isMV, gc)
 	case types.StrongCoin1EchoType:
@@ -87,7 +89,7 @@ func GenerateCoinMessageStateInterface(coinType types.CoinType, isMV bool, pid i
 
 func GenerateCoinIterfaceItem(coinType types.CoinType) consinterface.CoinItemInterface {
 	switch coinType {
-	case types.KnownCoinType:
+	case types.KnownCoinType, types.FlipCoinType:
 		return knowncoin.NewKnownCoin()
 	case types.StrongCoin1Type:
 		return strongcoin1.NewStrongCoin1()
@@ -106,7 +108,7 @@ func GenerateCoinIterfaceItem(coinType types.CoinType) consinterface.CoinItemInt
 
 func GetCoinHeader(emptyPub sig.Pub, gc *generalconfig.GeneralConfig, headerType messages.HeaderID) (messages.MsgHeader, error) {
 	switch gc.CoinType {
-	case types.KnownCoinType:
+	case types.KnownCoinType, types.FlipCoinType:
 		return knowncoin.KnownCoin{}.GetHeader(emptyPub, gc, headerType)
 	case types.StrongCoin1Type:
 		return strongcoin1.StrongCoin1{}.GetHeader(emptyPub, gc, headerType)
@@ -126,7 +128,7 @@ func GetBufferCount(hdr messages.MsgIDHeader, gc *generalconfig.GeneralConfig,
 	memberChecker *consinterface.MemCheckers) (int, int, messages.MsgID, error) {
 
 	switch gc.CoinType {
-	case types.KnownCoinType:
+	case types.KnownCoinType, types.FlipCoinType:
 		return knowncoin.KnownCoin{}.GetBufferCount(hdr, gc, memberChecker)
 	case types.StrongCoin1Type:
 		return strongcoin1.StrongCoin1{}.GetBufferCount(hdr, gc, memberChecker)

--- a/consensus/coin/knowncoin/knowncoinmsgstate.go
+++ b/consensus/coin/knowncoin/knowncoinmsgstate.go
@@ -38,6 +38,14 @@ type MsgState struct {
 	coinVal       map[types.ConsensusRound]types.BinVal
 	fixedCoinRand *rand.Rand // Used if we are using a fixed coin values for experiment repeatability
 	fixedCoinUint uint64     // Used if we are using a fixed coin values for experiment repeatability
+	flipCoin      bool       // if true coin flips from 1 to 0 each round
+}
+
+func NewFlipCoinMsgState(isMv bool,
+	_ *generalconfig.GeneralConfig) *MsgState {
+
+	_ = isMv // TODO
+	return &MsgState{flipCoin: true}
 }
 
 // NewKnownCoinMsgState generates a new KnownCoinMsgState object.
@@ -60,6 +68,10 @@ func (sms *MsgState) New(_ types.ConsensusIndex, presets []struct {
 	Round types.ConsensusRound
 	Val   types.BinVal
 }) consinterface.CoinMessageStateInterface {
+
+	if sms.flipCoin {
+		return &MsgState{flipCoin: true}
+	}
 
 	var fixedCoinUint uint64
 	fixedCoinUint = sms.fixedCoinRand.Uint64()
@@ -88,6 +100,11 @@ func (sms *MsgState) GetCoins(round types.ConsensusRound) []types.BinVal {
 }
 
 func (sms *MsgState) getCoin(round types.ConsensusRound) types.BinVal {
+	if sms.flipCoin {
+		// even rounds are 1
+		return types.BinVal((round + 1) % 2)
+	}
+
 	if val, ok := sms.coinVal[round]; ok {
 		return val
 	}

--- a/consensus/coin/knowncoin/knowncoinmsgstate.go
+++ b/consensus/coin/knowncoin/knowncoinmsgstate.go
@@ -101,8 +101,8 @@ func (sms *MsgState) GetCoins(round types.ConsensusRound) []types.BinVal {
 
 func (sms *MsgState) getCoin(round types.ConsensusRound) types.BinVal {
 	if sms.flipCoin {
-		// even rounds are 1
-		return types.BinVal((round + 1) % 2)
+		// odd rounds are 1
+		return types.BinVal(((round + 1) / 2) % 2)
 	}
 
 	if val, ok := sms.coinVal[round]; ok {

--- a/consensus/cons/bincons1/bin_cons1.go
+++ b/consensus/cons/bincons1/bin_cons1.go
@@ -125,6 +125,14 @@ func (sc *BinCons1) GetProposalIndex() (prevIdx types.ConsensusIndex, ready bool
 	return types.ConsensusIndex{}, false
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinCons1) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	auxMsg := messagetypes.NewAuxProofMessage(sc.AllowSupportCoin)
+	auxMsg.BinVal = val
+	auxMsg.Round = 1
+	return auxMsg
+}
+
 // GotProposal takes the proposal, creates a round 0 AuxProofMessage and broadcasts it.
 func (sc *BinCons1) GotProposal(hdr messages.MsgHeader, mainChannel channelinterface.MainChannel) error {
 	sc.AbsGotProposal()
@@ -424,7 +432,7 @@ func (sc *BinCons1) CheckRound(nmt int, t int, round types.ConsensusRound,
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinCons1) HasReceivedProposal() bool {
+func (sc *BinCons1) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/bincons1/bin_cons1_message_state.go
+++ b/consensus/cons/bincons1/bin_cons1_message_state.go
@@ -77,7 +77,7 @@ func (sms *MessageState) SetMv0Valid() {
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(_ *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/bincons1/bincons1_test.go
+++ b/consensus/cons/bincons1/bincons1_test.go
@@ -69,13 +69,13 @@ func TestBinCons1SleepMultiSig(t *testing.T) {
 }
 
 func TestBinCons1P2p(t *testing.T) {
-	cons.RunP2pNwTests(binTO, types.BinCons1Type, &BinCons1{}, Config{}, nil, t)
+	cons.RunP2pNwTests(binTO, types.BinCons1Type, &BinCons1{}, Config{}, []int{}, t)
 }
 
 func TestBinCons1SleepP2p(t *testing.T) {
 	to := binTO
 	to.SleepCrypto = true
-	cons.RunP2pNwTests(to, types.BinCons1Type, &BinCons1{}, Config{}, nil, t)
+	cons.RunP2pNwTests(to, types.BinCons1Type, &BinCons1{}, Config{}, []int{13}, t)
 }
 
 func TestBinCons1FailDisk(t *testing.T) {

--- a/consensus/cons/bincons1/binconsinterface.go
+++ b/consensus/cons/bincons1/binconsinterface.go
@@ -62,7 +62,7 @@ type BinConsMessageStateInterface interface {
 	// SetMv0Valid is called by the multivalue reduction MvCons1, when 0 becomes valid for round 1
 	SetMv0Valid()
 	// SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-	SetMv1Valid()
+	SetMv1Valid(mc *consinterface.MemCheckers)
 
 	// sentProposal returns true if a proposal has been sent for round+1 (i.e. the following round)
 	// if shouldSet is true, then sets to having sent the proposal for that round to true

--- a/consensus/cons/binconsrnd1/binconsrnd1.go
+++ b/consensus/cons/binconsrnd1/binconsrnd1.go
@@ -109,6 +109,14 @@ func (sc *BinConsRnd1) Start() {
 	}
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinConsRnd1) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	auxMsg := messagetypes.NewAuxProofMessage(sc.AllowSupportCoin)
+	auxMsg.BinVal = val
+	auxMsg.Round = 1
+	return auxMsg
+}
+
 // GetProposalIndex returns sc.Index - 1.
 // It returns false until start is called.
 func (sc *BinConsRnd1) GetProposalIndex() (prevIdx types.ConsensusIndex, ready bool) {
@@ -213,7 +221,7 @@ func (sc *BinConsRnd1) CanSkipMvTimeout() bool {
 	msgState.Lock()
 	defer msgState.Unlock()
 
-	return msgState.getAuxRoundStruct(2, sc.ConsItems.MC).TotalBinMsgCount >
+	return msgState.getAuxRoundStruct(2, sc.ConsItems.MC).TotalBinMsgCount >=
 		sc.ConsItems.MC.MC.GetMemberCount()-sc.ConsItems.MC.MC.GetFaultCount()
 }
 
@@ -600,7 +608,7 @@ func (sc *BinConsRnd1) checkBroadcasts(nmt int, t int, round types.ConsensusRoun
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinConsRnd1) HasReceivedProposal() bool {
+func (sc *BinConsRnd1) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/binconsrnd1/binconsrnd1_message_state.go
+++ b/consensus/cons/binconsrnd1/binconsrnd1_message_state.go
@@ -120,7 +120,7 @@ func (sms *MessageState) SetMv0Valid() {
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(_ *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/binconsrnd1/binconsrnd1_test.go
+++ b/consensus/cons/binconsrnd1/binconsrnd1_test.go
@@ -37,6 +37,7 @@ func getBinConsStateMachineTypes() []types.StateMachineType {
 // var binTO = types.TestOptions{SigType: types.TBLS, BinConsPercentOnes: 50, CoinType: types.StrongCoin1Type, IncludeProofs:true, StopOnCommit:types.SendProof, AllowSupportCoin:true}
 var binTO = types.TestOptions{SigType: types.TBLSDual, BinConsPercentOnes: 50, CoinType: types.StrongCoin1Type, IncludeProofs: true, UseFixedSeed: false, UseFixedCoinPresets: false, StopOnCommit: types.SendProof}
 var binTOKnown = types.TestOptions{SigType: types.EDCOIN, BinConsPercentOnes: 50, CoinType: types.KnownCoinType, UseFixedCoinPresets: false}
+var binTOFlip = types.TestOptions{SigType: types.EDCOIN, BinConsPercentOnes: 50, CoinType: types.FlipCoinType, UseFixedCoinPresets: false}
 var binTOStrongCoin2 = types.TestOptions{UseFixedSeed: false, SigType: types.EDCOIN, BinConsPercentOnes: 50, CoinType: types.StrongCoin2Type}
 var binTOStrongCoin2Echo = types.TestOptions{UseFixedSeed: false, SigType: types.EDCOIN, BinConsPercentOnes: 50, CoinType: types.StrongCoin2EchoType, EncryptChannels: true}
 var binTOStrongCoin1Echo = types.TestOptions{UseFixedSeed: false, SigType: types.TBLSDual, BinConsPercentOnes: 50, CoinType: types.StrongCoin1EchoType, EncryptChannels: true}
@@ -55,6 +56,11 @@ func TestBinConsRnd1SleepBasic(t *testing.T) {
 
 func TestBinConsRnd1BasicKnown(t *testing.T) {
 	cons.RunBasicTests(binTOKnown, types.BinConsRnd1Type, &BinConsRnd1{},
+		Config{}, []int{}, t)
+}
+
+func TestBinConsRnd1BasicFlip(t *testing.T) {
+	cons.RunBasicTests(binTOFlip, types.BinConsRnd1Type, &BinConsRnd1{},
 		Config{}, []int{}, t)
 }
 

--- a/consensus/cons/binconsrnd2/binconsrnd2.go
+++ b/consensus/cons/binconsrnd2/binconsrnd2.go
@@ -380,11 +380,16 @@ func (sc *BinConsRnd2) checkDone(rnd types.ConsensusRound, nmt, t int) bool {
 	case types.NextRound:
 		// If for the decided round, we have no not coin messages, then we think we are done (at least until we get more messages)
 		// because everyone we know would have decided in this round.
+		// If we are using local rand then we can't exit if we have no not coin messages as everyone may have a different
+		// set of non-faulty members
 		binMsgState := sc.getMsgState()
 		decidedRoundStruct := binMsgState.getAuxRoundStruct(sc.decidedRound, sc.ConsItems.MC)
 		valids, _ := binMsgState.getMostRecentValids(nmt, t, sc.decidedRound, sc.ConsItems.MC)
 		notCoin := 1 - decidedRoundStruct.coinVal
-		if decidedRoundStruct.AuxBinNums[notCoin] == 0 || !valids[notCoin] {
+
+		if (sc.ConsItems.MC.MC.RandMemberType() != types.LocalRandMember && decidedRoundStruct.AuxBinNums[notCoin] == 0) ||
+			!valids[notCoin] {
+
 			return true
 		}
 
@@ -450,9 +455,6 @@ func (sc *BinConsRnd2) checkBVAuxBroadcasts(nmt int, t int, round types.Consensu
 				// Store the values
 				roundStruct.supportBvInfo[i].echod = true
 				// Broadcast the message for the next round
-				if roundStruct.supportBvInfo[i].round == 1 && i == 1 {
-					fmt.Println("a")
-				}
 				auxMsg := messagetypes.CreateBVMessage(i, roundStruct.supportBvInfo[i].round)
 				// Set to true before checking if we are a member, since check member will always
 				// give the same result for this round

--- a/consensus/cons/binconsrnd2/binconsrnd2_message_state.go
+++ b/consensus/cons/binconsrnd2/binconsrnd2_message_state.go
@@ -84,9 +84,9 @@ type MessageState struct {
 	auxValues map[types.ConsensusRound]*auxRandRoundStruct // map from round index to auxRandRoundStruct
 	index     types.ConsensusIndex                         // consensus index
 	isMv      bool                                         // true if this is being used as part of mv cons
-	mv0Valid  bool                                         // for use with multivalued reduction MvCons1, set to true if 0 is valid for round 1
-	mv1Valid  bool                                         // for use with multivalued reduction MvCons1, set to true if 1 is valid for round 1
-	gc        *generalconfig.GeneralConfig                 // configuration object
+	// mv0Valid  bool                                         // for use with multivalued reduction MvCons1, set to true if 0 is valid for round 1
+	// mv1Valid  bool                                         // for use with multivalued reduction MvCons1, set to true if 1 is valid for round 1
+	gc        *generalconfig.GeneralConfig // configuration object
 	coinState consinterface.CoinMessageStateInterface
 	mutex     sync.RWMutex
 }
@@ -99,24 +99,25 @@ func (sms *MessageState) SetSimpleMessageStateWrapper(sm *messagestate.SimpleMes
 
 // SetMv0Valid is called by the multivalue reduction MvCons1, when 0 becomes valid for round 1
 func (sms *MessageState) SetMv0Valid() {
+	panic("unused")
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
-	if !sms.mv0Valid {
-		logging.Info("Setting 0 valid for mv cons for index", sms.index)
-		sms.mv0Valid = true
-	}
+	// if !sms.mv0Valid {
+	// 	logging.Info("Setting 0 valid for mv cons for index", sms.index)
+	//	sms.mv0Valid = true
+	// }
 	// sms.mutex.Unlock()
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(mc *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
-	// sms.mutex.Lock()
-	if !sms.mv1Valid {
-		logging.Info("Setting 1 valid for mv cons for index", sms.index)
-		sms.mv1Valid = true
-	}
-	// sms.mutex.Unlock()
+	sms.mutex.Lock()
+	defer sms.mutex.Unlock()
+
+	rs := sms.getAuxRoundStruct(1, mc)
+	nmt := mc.MC.GetMemberCount() - mc.MC.GetFaultCount()
+	rs.supportBvInfo[1].msgCount = nmt
 }
 
 // Lock the object
@@ -166,11 +167,10 @@ func (sms *MessageState) SentProposal(round types.ConsensusRound,
 
 	var ret bool
 	sms.mutex.Lock()
-	panic("TODO mv reduction")
-	//ars := sms.getAuxRoundStruct(round, mc)
-	//ret = ars.sentProposal
+	ars := sms.getAuxRoundStruct(round+1, mc)
+	ret = ars.sentProposal
 	if shouldSet {
-		// ars.sentProposal = shouldSet
+		ars.sentProposal = shouldSet
 	}
 	sms.mutex.Unlock()
 	return ret
@@ -222,14 +222,10 @@ func (sms *MessageState) getAuxRoundStruct(round types.ConsensusRound,
 			item.supportBvInfo[1] = &item.bvInfo[1]
 			item.checkedCoin = true
 			item.prevCoinVal = 1
-		} else if round == 1 && sms.isMv { // when using mv reduction, first round coin value is always 1 so we can decide 1 right away
-			item.gotCoin = true
-			item.sentCoin = true
-			item.prevCoinVal = 1
-			item.checkedCoin = true
-			item.coinVal = 1
-			// TODO what about bv info?
-			panic("TODO")
+			if sms.isMv {
+				// sending of bv messages is done by the multi-value reduction
+				item.supportBvInfo[1].echod = true
+			}
 		}
 		sms.auxValues[round] = item
 	}
@@ -263,12 +259,20 @@ func (sms *MessageState) GotMsg(hdrFunc consinterface.HeaderFunc,
 	// Update the round struct with the new pubs
 	// we don't mind if someone already updated these in the mean time
 	sms.mutex.Lock()
+	defer sms.mutex.Unlock()
 
 	switch w := deser.Header.(messages.InternalSignedMsgHeader).GetBaseMsgHeader().(type) {
 	case *messagetypes.BVMessage0, *messagetypes.BVMessage1:
 		binVal, round, stage := messagetypes.GetBVMessageInfo(w)
+		if round == 0 {
+			return nil, types.ErrInvalidRound
+		}
 		if stage != 0 {
 			return nil, types.ErrInvalidStage
+		}
+		if sms.isMv && binVal == 1 && round == 1 {
+			// round 1 is controlled by the mv reduction
+			return nil, types.ErrInvalidRound
 		}
 		roundStruct := sms.getAuxRoundStruct(round, mc)
 
@@ -302,7 +306,6 @@ func (sms *MessageState) GotMsg(hdrFunc consinterface.HeaderFunc,
 
 	}
 
-	sms.mutex.Unlock()
 	return ret, nil
 }
 
@@ -318,23 +321,24 @@ func (sms *MessageState) getMostRecentValids(nmt, t int, round types.ConsensusRo
 	mc *consinterface.MemCheckers) (valids [2]bool, validRounds [2]types.ConsensusRound) {
 
 	_ = t
-	if round == 0 && sms.isMv {
-		// false
-	} else if round == 1 && sms.isMv {
-		// special case when used in multivalue (set by SetMv1Valid() and SetMv0Valid())
-		valids[0], valids[1] = sms.mv0Valid, sms.mv1Valid
-	} else {
-		ars := sms.getAuxRoundStruct(round, mc)
-		if ars.supportBvInfo[0] != nil {
-			if !ars.gotPrevCoin {
-				panic("should have gotten coin")
-			}
-			for i := 0; i < 2; i++ {
-				valids[i] = ars.supportBvInfo[i].msgCount >= nmt
-				validRounds[i] = ars.supportBvInfo[i].round
-			}
+	/*	if round == 0 && sms.isMv {
+			// false
+		} else if round == 1 && sms.isMv {
+			// special case when used in multivalue (set by SetMv1Valid() and SetMv0Valid())
+			valids[0], valids[1] = sms.mv0Valid, sms.mv1Valid
+		} else {
+	*/
+	ars := sms.getAuxRoundStruct(round, mc)
+	if ars.supportBvInfo[0] != nil {
+		if !ars.gotPrevCoin {
+			panic("should have gotten coin")
+		}
+		for i := 0; i < 2; i++ {
+			valids[i] = ars.supportBvInfo[i].msgCount >= nmt
+			validRounds[i] = ars.supportBvInfo[i].round
 		}
 	}
+	// }
 	return
 }
 
@@ -346,18 +350,18 @@ func (sms *MessageState) GenerateProofs(headerID messages.HeaderID, sigCount int
 		panic("invalid header id")
 	}
 
-	// if MvCons and round == 2, est == 1, then we could not have decided 0, so we dont need proofs
-	// (the proofs are the echo messages from mv-cons)
-	if round <= 2 && binVal == 1 && sms.mv1Valid {
-		panic("TODO")
-		return nil, nil
-	}
-	// When using mv and round = 1 we dont need proofs for 0 since it is made valid on a timeout.
-	if round == 1 && binVal == 0 && sms.mv0Valid {
-		panic("TODO")
-		return nil, nil
-	}
-
+	/*	// if MvCons and round == 2, est == 1, then we could not have decided 0, so we dont need proofs
+		// (the proofs are the echo messages from mv-cons)
+		if round <= 2 && binVal == 1 && sms.mv1Valid {
+			panic("TODO")
+			return nil, nil
+		}
+		// When using mv and round = 1 we dont need proofs for 0 since it is made valid on a timeout.
+		if round == 1 && binVal == 0 && sms.mv0Valid {
+			panic("TODO")
+			return nil, nil
+		}
+	*/
 	t := mc.MC.GetFaultCount()
 	nmt := mc.MC.GetMemberCount() - t
 	// var ret []*sig.MultipleSignedMessage

--- a/consensus/cons/binconsrnd2/binconsrnd2_message_state.go
+++ b/consensus/cons/binconsrnd2/binconsrnd2_message_state.go
@@ -203,6 +203,7 @@ func (sms *MessageState) GetProofs(headerID messages.HeaderID, sigCount int,
 func (sms *MessageState) GetValidMessageCount(round types.ConsensusRound, mc *consinterface.MemCheckers) int {
 	sms.mutex.Lock()
 	defer sms.mutex.Unlock()
+
 	roundStruct := sms.getAuxRoundStruct(round, mc)
 	return roundStruct.TotalAuxBinMsgCount
 }
@@ -229,6 +230,7 @@ func (sms *MessageState) getAuxRoundStruct(round types.ConsensusRound,
 		}
 		sms.auxValues[round] = item
 	}
+
 	return item
 }
 

--- a/consensus/cons/binconsrnd3/binconsrnd3.go
+++ b/consensus/cons/binconsrnd3/binconsrnd3.go
@@ -262,6 +262,8 @@ func (sc *BinConsRnd3) CheckRound(nmt int, t int, round types.ConsensusRound,
 
 				// update the count for supporters of the coin in the next round
 				nxtRndStruct.BinNumsAux[roundStruct.coinVals[0]], _ = binMsgState.Sms.GetTotalSigCount(sc.ConsItems.MC, auxMsg, auxMsgCoin)
+				// this may cause a new both message type to be valid so we check it
+				binMsgState.updateBothMsgCount(round, roundStruct, sc.ConsItems.MC)
 			}
 		}
 	}
@@ -269,9 +271,10 @@ func (sc *BinConsRnd3) CheckRound(nmt int, t int, round types.ConsensusRound,
 	if round > 0 {
 		prvRoundStruct := sc.getMsgState().getAuxRoundStruct(round-1, sc.ConsItems.MC)
 		if round > 1 {
+			// See if we have enough information to check Aux messages for this round
 			if sc.CheckMemberLocal() && (!prvRoundStruct.sentAuxProof ||
 				!prvRoundStruct.sentAuxBoth || (!prvRoundStruct.sentCoin && !sc.GeneralConfig.AllowSupportCoin)) {
-
+				// have not yet received enough messages
 				return false
 			}
 		}

--- a/consensus/cons/binconsrnd3/binconsrnd3.go
+++ b/consensus/cons/binconsrnd3/binconsrnd3.go
@@ -106,6 +106,11 @@ func (sc *BinConsRnd3) Start() {
 	}
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinConsRnd3) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	panic("TODO")
+}
+
 // GetProposalIndex returns sc.Index - 1.
 // It returns false until start is called.
 func (sc *BinConsRnd3) GetProposalIndex() (prevIdx types.ConsensusIndex, ready bool) {
@@ -621,7 +626,7 @@ func (sc *BinConsRnd3) generateProofsInternal(hdr messages.MsgIDHeader, supportC
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinConsRnd3) HasReceivedProposal() bool {
+func (sc *BinConsRnd3) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/binconsrnd3/binconsrnd3_message_state.go
+++ b/consensus/cons/binconsrnd3/binconsrnd3_message_state.go
@@ -166,7 +166,7 @@ func (sms *MessageState) getValidsAuxBoth(round types.ConsensusRound, mc *consin
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(_ *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/binconsrnd4/binconsrnd4.go
+++ b/consensus/cons/binconsrnd4/binconsrnd4.go
@@ -115,6 +115,11 @@ func (sc *BinConsRnd4) GetProposalIndex() (prevIdx types.ConsensusIndex, ready b
 	return types.ConsensusIndex{}, false
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinConsRnd4) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	panic("TODO")
+}
+
 // GotProposal takes the proposal, creates a round 0 AuxProofMessage and broadcasts it.
 func (sc *BinConsRnd4) GotProposal(hdr messages.MsgHeader, _ channelinterface.MainChannel) error {
 	sc.AbsGotProposal()
@@ -594,7 +599,7 @@ func (sc *BinConsRnd4) broadcastMsg(msgType messages.HeaderID, binVal types.BinV
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinConsRnd4) HasReceivedProposal() bool {
+func (sc *BinConsRnd4) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/binconsrnd4/binconsrnd4_message_state.go
+++ b/consensus/cons/binconsrnd4/binconsrnd4_message_state.go
@@ -113,7 +113,7 @@ func (sms *MessageState) SetMv0Valid() {
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(_ *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/binconsrnd5/binconsrnd5.go
+++ b/consensus/cons/binconsrnd5/binconsrnd5.go
@@ -153,6 +153,11 @@ func (sc *BinConsRnd5) GotProposal(hdr messages.MsgHeader, mainChannel channelin
 	return nil
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinConsRnd5) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	panic("TODO")
+}
+
 // NeedsConcurrent returns 1.
 func (sc *BinConsRnd5) NeedsConcurrent() types.ConsensusInt {
 	return 1
@@ -690,7 +695,7 @@ func (sc *BinConsRnd5) generateProofsInternal(hdr messages.MsgIDHeader, supportC
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinConsRnd5) HasReceivedProposal() bool {
+func (sc *BinConsRnd5) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/binconsrnd5/binconsrnd5_message_state.go
+++ b/consensus/cons/binconsrnd5/binconsrnd5_message_state.go
@@ -182,7 +182,7 @@ func (sms *MessageState) getValidsAuxBoth(round types.ConsensusRound, mc *consin
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(*consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/binconsrnd6/binconsrnd6.go
+++ b/consensus/cons/binconsrnd6/binconsrnd6.go
@@ -148,6 +148,11 @@ func (sc *BinConsRnd6) GotProposal(hdr messages.MsgHeader, _ channelinterface.Ma
 	return nil
 }
 
+// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for round 0.
+func (sc *BinConsRnd6) GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader {
+	panic("TODO")
+}
+
 // NeedsConcurrent returns 1.
 func (sc *BinConsRnd6) NeedsConcurrent() types.ConsensusInt {
 	return 1
@@ -719,7 +724,7 @@ func (sc *BinConsRnd6) broadcastMsg(msgType messages.HeaderID, binVal types.BinV
 }
 
 // HasReceivedProposal panics because BonCons has no proposals.
-func (sc *BinConsRnd6) HasReceivedProposal() bool {
+func (sc *BinConsRnd6) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/binconsrnd6/binconsrnd6_message_state.go
+++ b/consensus/cons/binconsrnd6/binconsrnd6_message_state.go
@@ -113,7 +113,7 @@ func (sms *MessageState) SetMv0Valid() {
 }
 
 // SetMv1Valid is called by the multivalue reduction MvCons1, when 1 becomes valid for round 1
-func (sms *MessageState) SetMv1Valid() {
+func (sms *MessageState) SetMv1Valid(_ *consinterface.MemCheckers) {
 	// dont need locks because only accessed in main thread
 	// sms.mutex.Lock()
 	if !sms.mv1Valid {

--- a/consensus/cons/configs.go
+++ b/consensus/cons/configs.go
@@ -24,73 +24,11 @@ import (
 	"github.com/tcrain/cons/consensus/types"
 )
 
-/*func sigComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	noSignatures = false
-	switch options.EncryptChannels {
-	case types.ConsDepedentChannels:
-		switch options.CoinType {
-		case types.StrongCoin1EchoType, types.StrongCoin2EchoType:
-			encryptChannels = true
-		}
-	case types.EncryptedChannels:
-		encryptChannels = true
-	case types.NonEncryptedChannels:
-		encryptChannels = false
-	default:
-		panic(options.EncryptChannels)
-	}
-	return
-}
-
-func NonSigComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	switch options.NoSignatures {
-	case types.ConsDependentSignatures:
-		noSignatures = true
-	case types.NoSignatures:
-		return true, true
-	case types.UseSignatures:
-		noSignatures = false
-	default:
-		panic(options.NoSignatures)
-	}
-	switch options.EncryptChannels {
-	case types.ConsDepedentChannels:
-		if !noSignatures {
-			switch options.CoinType {
-			case types.StrongCoin1EchoType, types.StrongCoin2EchoType:
-				encryptChannels = true
-			default:
-				encryptChannels = false
-			}
-		} else {
-			encryptChannels = true
-		}
-	case types.EncryptedChannels:
-		encryptChannels = true
-	case types.NonEncryptedChannels:
-		if !noSignatures {
-			encryptChannels = false
-		} else {
-			encryptChannels = true
-		}
-	default:
-		panic(options.EncryptChannels)
-	}
-	return
-}
-*/
-
 type StandardMvConfig struct{}
 
 // GetCoinTypes returns the types of coins allowed.
 func (StandardMvConfig) GetCoinTypes(optionType GetOptionType) []types.CoinType {
 	return []types.CoinType{types.NoCoinType}
-}
-
-// ComputeSigAndEncoding returns whether signatures should be used or messages should be encoded
-func (StandardMvConfig) ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	// return sigComputeSigAndEncoding(options)
-	return
 }
 
 // GetStopOnCommitTypes returns the types to test when to terminate.
@@ -258,12 +196,6 @@ func (StandardMvConfig) GetAllowConcurrentTypes(gt GetOptionType) []bool {
 //////////////////////////////////////////////////////////////////////
 
 type StandardBinConfig struct{}
-
-// ComputeSigAndEncoding returns whether signatures should be used or messages should be encoded
-func (StandardBinConfig) ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	// return sigComputeSigAndEncoding(options)
-	return
-}
 
 // GetCoinTypes returns the types of coins allowed.
 func (StandardBinConfig) GetCoinTypes(optionType GetOptionType) []types.CoinType {
@@ -450,12 +382,6 @@ func (SimpleConsConfig) GetStopOnCommitTypes(optionType GetOptionType) []types.S
 // GetCoinTypes returns the types of coins allowed.
 func (SimpleConsConfig) GetCoinTypes(optionType GetOptionType) []types.CoinType {
 	return []types.CoinType{types.NoCoinType}
-}
-
-// ComputeSigAndEncoding returns whether signatures should be used or messages should be encoded
-func (SimpleConsConfig) ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	// return sigComputeSigAndEncoding(options)
-	return
 }
 
 // GetBroadcastFunc returns the broadcast function for the given byzantine type

--- a/consensus/cons/interfaces.go
+++ b/consensus/cons/interfaces.go
@@ -71,6 +71,8 @@ type BinConsInterface interface {
 	CanSkipMvTimeout() bool
 	// GetBinDecided returns -1 if not decided, or the decided value, and the round decided.
 	GetBinDecided() (int, types.ConsensusRound)
+	// GetMVInitialRoundBroadcast returns the type of binary message that the multi-value reduction should broadcast for the initial round.
+	GetMVInitialRoundBroadcast(val types.BinVal) messages.InternalSignedMsgHeader
 }
 
 // GetMvMsgRound is a helper method to the the round from either a MvInitMessage, PartialMessage, MvCommitMessage, MvEchoMessage
@@ -97,7 +99,7 @@ func GetMvMsgRound(deser *channelinterface.DeserializedItem) (round types.Consen
 // ConfigOptions is an interface that returns the set of valid configurations for a given consensus implementation.
 // Each consensus implementation should create an implementation of this interface so tests can be run on the valid configs.
 type ConfigOptions interface {
-	ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool)
+	// ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool)
 
 	// GetIsMV returns true if the consensus is multi-value or false if binary.
 	GetIsMV() bool

--- a/consensus/cons/mvbinconsrnd2/configoptions.go
+++ b/consensus/cons/mvbinconsrnd2/configoptions.go
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
-package binconsrnd2
+package mvbinconsrnd2
 
 import (
 	"github.com/tcrain/cons/consensus/cons"
@@ -25,8 +25,38 @@ import (
 )
 
 type Config struct {
-	cons.StandardBinConfig
+	cons.StandardMvConfig
 }
+
+// GetAllowNoSignatures returns true if the consensus can run without signatures
+func (Config) GetAllowNoSignatures(gt cons.GetOptionType) []bool { // []types.UseSignaturesType {
+	switch gt {
+	case cons.AllOptions:
+		// return []types.UseSignaturesType{types.ConsDependentSignatures, types.UseSignatures, types.NoSignatures}
+		return types.WithBothBool
+	case cons.MinOptions:
+		// return []types.UseSignaturesType{types.NoSignatures}
+		return types.WithTrue
+	default:
+		panic(gt)
+	}
+}
+
+// GetOrderingTypes returns the types of ordering supported by the consensus.
+//func (RbBcast1Config) GetOrderingTypes(gt types.GetOptionType) []types.OrderingType {
+//	return []types.OrderingType{types.Causal}
+//}
+
+// GetIncludeProofTypes returns the values for if the consensus supports including proofs or not or both.
+func (Config) GetIncludeProofsTypes(_ cons.GetOptionType) []bool {
+	return types.WithFalse
+}
+
+// GetUseMultiSigTypes() []bool
+// GetRotateCoordTypes returns the values for if the consensus supports rotating coordinator or not or both.
+//func (Config) GetRotateCoordTypes(gt cons.GetOptionType) []bool {
+//	return types.WithFalse
+//}
 
 // GetStopOnCommitTypes returns the types to test when to terminate.
 func (Config) GetStopOnCommitTypes(optionType cons.GetOptionType) []types.StopOnCommitType {
@@ -38,12 +68,6 @@ func (Config) GetStopOnCommitTypes(optionType cons.GetOptionType) []types.StopOn
 	default:
 		panic(optionType)
 	}
-}
-
-// ComputeSigAndEncoding returns whether signatures should be used or messages should be encoded
-func (Config) ComputeSigAndEncoding(options types.TestOptions) (noSignatures, encryptChannels bool) {
-	// return cons.NonSigComputeSigAndEncoding(options)
-	return
 }
 
 // GetCoinTypes returns the types of coins allowed.
@@ -58,25 +82,11 @@ func (Config) GetCoinTypes(optionType cons.GetOptionType) []types.CoinType {
 	}
 }
 
-// GetAllowNoSignatures returns true if the consensus can run without signatures
-func (Config) GetAllowNoSignatures(gt cons.GetOptionType) []bool { // []types.UseSignaturesType {
-	switch gt {
-	case cons.AllOptions:
-		// return []types.UseSignaturesType{types.ConsDependentSignatures, types.UseSignatures, types.NoSignatures}
-		return types.WithBothBool
-	case cons.MinOptions:
-		// return []types.UseSignaturesType{types.UseSignatures}
-		return types.WithTrue
-	default:
-		panic(gt)
-	}
-}
-
 // GetSigTypes return the types of signatures supported by the consensus
 func (Config) GetSigTypes(gt cons.GetOptionType) []types.SigType {
 	switch gt {
 	case cons.AllOptions:
-		return types.CoinSigTypes
+		return types.AllSigTypes
 	case cons.MinOptions:
 		return []types.SigType{types.EDCOIN}
 	default:
@@ -87,9 +97,4 @@ func (Config) GetSigTypes(gt cons.GetOptionType) []types.SigType {
 // GetUsePubIndex returns the values for if the consensus supports using pub index or not or both.
 func (Config) GetUsePubIndexTypes(_ cons.GetOptionType) []bool {
 	return types.WithTrue
-}
-
-// GetRotateCoordTypes returns the values for if the consensus supports rotating coordinator or not or both.
-func (Config) GetRotateCoordTypes(_ cons.GetOptionType) []bool {
-	return types.WithFalse
 }

--- a/consensus/cons/mvbinconsrnd2/mvbinconsrnd2_message_state.go
+++ b/consensus/cons/mvbinconsrnd2/mvbinconsrnd2_message_state.go
@@ -1,0 +1,243 @@
+/*
+github.com/tcrain/cons - Experimental project for testing and scaling consensus algorithms.
+Copyright (C) 2020 The project authors - tcrain
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+package mvbinconsrnd2
+
+import (
+	"bytes"
+	"github.com/tcrain/cons/consensus/auth/sig"
+	"github.com/tcrain/cons/consensus/channelinterface"
+	"github.com/tcrain/cons/consensus/cons"
+	"github.com/tcrain/cons/consensus/cons/bincons1"
+	"github.com/tcrain/cons/consensus/cons/binconsrnd2"
+	"github.com/tcrain/cons/consensus/consinterface"
+	"github.com/tcrain/cons/consensus/consinterface/messagestate"
+	"github.com/tcrain/cons/consensus/generalconfig"
+	"github.com/tcrain/cons/consensus/logging"
+	"github.com/tcrain/cons/consensus/messages"
+	"github.com/tcrain/cons/consensus/messagetypes"
+	"github.com/tcrain/cons/consensus/types"
+	"sync"
+)
+
+// RbBcast1Message state stores the message of RbBcast.
+type MessageState struct {
+	*messagestate.SimpleMessageStateWrapper                      // the simple message state is used to track the actual messages
+	index                                   types.ConsensusIndex // consensus index
+	mutex                                   sync.RWMutex
+	supportedEchoHash                       types.HashBytes // the hash of the echo message supported
+	totalEchoMsgCount                       int             // max number of a echo of messages we have received for this round
+	supportedCommitHash                     types.HashBytes // hash of the supported commit message
+	supportedCommitCount                    int             // number of messages we have received for the supported commit
+	bincons1.BinConsMessageStateInterface                   // the binary consensus messages
+}
+
+// NewMvBinConsRnd2MessageState generates a new MvBinConsRnd2MessageStateObject.
+func NewMvBinConsRnd2MessageState(gc *generalconfig.GeneralConfig) *MessageState {
+
+	binMsgState := binconsrnd2.NewBinConsRnd2MessageState(true, gc)
+	ret := &MessageState{
+		BinConsMessageStateInterface: binMsgState,
+		SimpleMessageStateWrapper:    messagestate.InitSimpleMessageStateWrapper(gc)}
+
+	return ret
+}
+
+// New inits and returns a new MvBinConsRnd2MessageState object for the given consensus index.
+func (sms *MessageState) New(idx types.ConsensusIndex) consinterface.MessageState {
+
+	ret := &MessageState{
+		// Use the same simple message state
+		BinConsMessageStateInterface: sms.BinConsMessageStateInterface.New(idx).(bincons1.BinConsMessageStateInterface),
+		index:                        idx,
+		SimpleMessageStateWrapper:    sms.SimpleMessageStateWrapper.NewWrapper(idx)}
+	// Use the same simple message state
+	ret.BinConsMessageStateInterface.SetSimpleMessageStateWrapper(ret.SimpleMessageStateWrapper)
+	return ret
+}
+
+/*// GetValidMessage count returns the number of signed echo and commit messages received from different processes in round round.
+func (sms *MessageState) GetValidMessageCount() (echoMsgCount int) {
+	sms.mutex.Lock()
+	defer sms.mutex.Unlock()
+	return sms.totalEchoMsgCount
+}
+*/
+// getSupportedEchoHash returns the echo hash supported for the round, or nil if there is none
+func (sms *MessageState) getSupportedEchoHash() types.HashBytes {
+	sms.mutex.Lock()
+	defer sms.mutex.Unlock()
+
+	return sms.supportedEchoHash
+}
+
+// getSupportedCommitHash returns the commit hash supported for the round, or nil if there is none, and the number of
+// messages received supporting it.
+func (sms *MessageState) getSupportedCommitHash() (hash types.HashBytes, msgCount int) {
+	sms.mutex.Lock()
+	defer sms.mutex.Unlock()
+
+	return sms.supportedCommitHash, sms.supportedCommitCount
+}
+
+// GotMessage takes a deserialized message and the member checker for the current consensus index.
+// If the message contains no new valid signatures then an error is returned.
+// The value newTotalSigCount is the new number of signatures for the specific message, the value newMsgIDSigCount is the
+// number of signatures for the MsgID of the message (see messages.MsgID).
+// The valid message types are
+// (1) HdrMvInit - the leaders proposal, here is ensures the message comes from the correct leader
+// (2) HdrMvEcho - echo messages
+// (3) HdrMvCommit - commit messages
+// (4) HdrMvRequestRecover - unsigned message asking for the init message received for a given hash
+func (sms *MessageState) GotMsg(hdrFunc consinterface.HeaderFunc,
+	deser *channelinterface.DeserializedItem, gc *generalconfig.GeneralConfig,
+	mc *consinterface.MemCheckers) ([]*channelinterface.DeserializedItem, error) {
+
+	if !deser.IsDeserialized {
+		// Only track deserialzed messages
+		panic("should be deserialized")
+	}
+
+	switch deser.HeaderType {
+	case messages.HdrMvInit, messages.HdrPartialMsg:
+
+		// An MvInit message should only be signed once
+		if err := sig.CheckSingleSupporter(deser.Header); err != nil {
+			return nil, err
+		}
+		// Check the membership/signatures/duplicates
+		ret, err := sms.Sms.GotMsg(hdrFunc, deser, gc, mc)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the message resulted in a combination then we will have the combined message and the partial message here
+		for _, nxt := range ret {
+
+			if err := consinterface.CheckMemberCoordHdr(mc, 0, deser.Header); err != nil {
+				return nil, err
+			}
+
+			if nxt.HeaderType == messages.HdrMvInit {
+				// handled in mv_cons2
+			}
+		}
+		return ret, nil
+	case messages.HdrMvEcho, messages.HdrMvCommit:
+		// Check the membership/signatures/duplicates
+		hdr, err := sms.Sms.GotMsg(hdrFunc, deser, gc, mc)
+		if err != nil {
+			return hdr, err
+		}
+		if len(hdr) != 1 {
+			panic("should not create a new msg")
+		}
+		if cons.GetMvMsgRound(hdr[0]) != 0 {
+			return nil, types.ErrInvalidRound
+		}
+		sms.mutex.Lock()
+
+		t := mc.MC.GetFaultCount()
+		nmt := mc.MC.GetMemberCount() - t
+		if deser.HeaderType == messages.HdrMvEcho {
+			// update the message count
+			if sms.totalEchoMsgCount < deser.NewMsgIDSigCount {
+				sms.totalEchoMsgCount = deser.NewMsgIDSigCount
+			}
+			// check if we can support an echo hash (i.e. we got n-t of the same hash)
+			if deser.NewTotalSigCount >= nmt {
+				hashBytes := hdr[0].Header.(messages.InternalSignedMsgHeader).GetBaseMsgHeader().(*messagetypes.MvEchoMessage).ProposalHash
+				if sms.supportedEchoHash != nil && !bytes.Equal(sms.supportedEchoHash, hashBytes) {
+					panic("got two hashes to support")
+				}
+				sms.supportedEchoHash = hashBytes
+			}
+		} else {
+			// Once we have more than t commit messages we can support the value
+			if deser.NewTotalSigCount > t {
+				hashBytes := hdr[0].Header.(messages.InternalSignedMsgHeader).GetBaseMsgHeader().(*messagetypes.MvCommitMessage).ProposalHash
+
+				if sms.supportedCommitHash != nil && !bytes.Equal(sms.supportedCommitHash, hashBytes) {
+					panic("got two hashes to support")
+				}
+				if sms.supportedEchoHash != nil && !bytes.Equal(sms.supportedEchoHash, hashBytes) {
+					panic("got conflicting echo and commit hashes")
+				}
+				sms.supportedCommitHash = hashBytes
+				if sms.supportedCommitCount < deser.NewTotalSigCount {
+					sms.supportedCommitCount = deser.NewTotalSigCount
+				}
+			}
+		}
+
+		sms.mutex.Unlock()
+		return hdr, err
+	case messages.HdrMvRequestRecover:
+		// we handle this in cons
+		// Nothing to do since it is just asking for a message
+		return []*channelinterface.DeserializedItem{deser}, nil
+	default:
+		// check if it is a bin cons message
+		return sms.BinConsMessageStateInterface.GotMsg(hdrFunc, deser, gc, mc)
+		// panic(fmt.Sprint("invalid msg type ", deser.HeaderType))
+	}
+}
+
+// Generate proofs returns a signed message with signatures supporting the input values,
+// it can be a MvEchoMessage.
+func (sms *MessageState) GenerateProofs(hdrID messages.HeaderID, sigCount int, round types.ConsensusRound, binVal types.BinVal,
+	pub sig.Pub, mc *consinterface.MemCheckers) ([]*sig.MultipleSignedMessage, error) {
+
+	if round == 0 && binVal == 1 {
+		// if we have n-t echo messages supporting a value, then we use that
+		var w messages.InternalSignedMsgHeader
+		var count int
+		var err error
+		// check echos
+		sms.mutex.Lock()
+		supportedEchoHash := sms.supportedEchoHash
+		sms.mutex.Unlock()
+		if len(supportedEchoHash) == 0 {
+			return nil, types.ErrNoEchoHash
+		} else {
+			echoMsg := messagetypes.NewMvEchoMessage()
+			echoMsg.ProposalHash = supportedEchoHash
+			count, err = sms.GetSigCountMsgHeader(echoMsg, mc)
+			if count >= sigCount {
+				w = echoMsg
+			} else {
+				return nil, types.ErrNoProofs
+			}
+		}
+
+		// Add sigs
+		prfMsgSig, err := sms.SetupSignedMessage(w, false, sigCount, mc)
+		if err != nil {
+			logging.Error(err)
+			return nil, err
+		}
+		if prfMsgSig.GetSigCount() < sigCount {
+			logging.Error("Not enough signatures for MV proofs: got, expected", prfMsgSig.GetSigCount(), sigCount, w.GetID())
+			err = types.ErrNotEnoughSigs
+		}
+		return []*sig.MultipleSignedMessage{prfMsgSig}, err
+	}
+
+	return sms.BinConsMessageStateInterface.GenerateProofs(hdrID, sigCount, round, binVal, pub, mc)
+}

--- a/consensus/cons/mvbinconsrnd2/mvbinconsrnd2_test.go
+++ b/consensus/cons/mvbinconsrnd2/mvbinconsrnd2_test.go
@@ -1,0 +1,117 @@
+/*
+github.com/tcrain/cons - Experimental project for testing and scaling consensus algorithms.
+Copyright (C) 2020 The project authors - tcrain
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+*/
+
+package mvbinconsrnd2
+
+import (
+	"github.com/tcrain/cons/config"
+	"github.com/tcrain/cons/consensus/cons"
+	"github.com/tcrain/cons/consensus/types"
+	"testing"
+)
+
+// getBinConsStateMachineTypes returns a list of the valid state machine types for multi-value consensus given the configuration.
+func getMvConsStateMachineTypes() []types.StateMachineType {
+	if config.RunAllTests {
+		return types.MultivalueProposerTypes
+	}
+	return []types.StateMachineType{types.CounterProposer}
+}
+
+var baseTO = types.TestOptions{EncryptChannels: true, NoSignatures: true, SigType: types.EDCOIN,
+	CoinType: types.StrongCoin2Type, StopOnCommit: types.NextRound}
+var fixedCoinTO = types.TestOptions{
+	CoinType: types.FlipCoinType, StopOnCommit: types.NextRound}
+var causalTO = types.TestOptions{OrderingType: types.Causal, EncryptChannels: true, NoSignatures: true,
+	CoinType: types.FlipCoinType, StopOnCommit: types.NextRound}
+
+func TestMvBinConsRnd2Basic(t *testing.T) {
+	cons.RunBasicTests(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2BasicSleep(t *testing.T) {
+	to := baseTO
+	to.SleepCrypto = true
+	cons.RunBasicTests(to, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2RandMC(t *testing.T) {
+	cons.RunRandMCTests(fixedCoinTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, true,
+		[]int{}, t)
+}
+
+func TestMvBinConsRnd2RandMCSleep(t *testing.T) {
+	to := fixedCoinTO
+	to.SleepCrypto = true
+	cons.RunRandMCTests(to, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, true,
+		[]int{}, t)
+}
+
+func TestMvBinConsRnd2Byz(t *testing.T) {
+	cons.RunByzTests(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2MemStore(t *testing.T) {
+	cons.RunMemstoreTest(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, nil, t)
+}
+
+func TestMvBinConsRnd2MsgDrop(t *testing.T) {
+	cons.RunMsgDropTest(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, nil, t)
+}
+
+func TestMvBinConsRnd2MultiSig(t *testing.T) {
+	cons.RunMultiSigTests(fixedCoinTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2P2p(t *testing.T) {
+	cons.RunP2pNwTests(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, nil, t)
+}
+
+func TestMvBinConsRnd2FailDisk(t *testing.T) {
+	cons.RunFailureTests(baseTO, types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, nil, t)
+}
+
+func TestMvBinConsRnd2CausalBasic(t *testing.T) {
+	cons.RunBasicTests(causalTO,
+		types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2CausalBasicSleep(t *testing.T) {
+	to := causalTO
+	to.SleepCrypto = true
+	cons.RunBasicTests(to,
+		types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2CausalFailDisk(t *testing.T) {
+	cons.RunFailureTests(causalTO,
+		types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, []int{}, t)
+}
+
+func TestMvBinConsRnd2CausalRandMC(t *testing.T) {
+	cons.RunRandMCTests(causalTO,
+		types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, true, []int{}, t)
+}
+
+func TestMvBinConsRnd2CausalRandMCSleep(t *testing.T) {
+	to := causalTO
+	to.SleepCrypto = true
+	cons.RunRandMCTests(to,
+		types.MvBinConsRnd2Type, &MvBinConsRnd2{}, Config{}, true, []int{}, t)
+}

--- a/consensus/cons/mvcons1/configoptions.go
+++ b/consensus/cons/mvcons1/configoptions.go
@@ -98,6 +98,78 @@ func (MvBinConsRnd1Config) GetUsePubIndexTypes(gt cons.GetOptionType) []bool {
 	return types.WithTrue
 }
 
+type MvBinConsRnd2Config struct {
+	cons.StandardMvConfig
+}
+
+// GetStopOnCommitTypes returns the types to test when to terminate.
+func (MvBinConsRnd2Config) GetStopOnCommitTypes(optionType cons.GetOptionType) []types.StopOnCommitType {
+	switch optionType {
+	case cons.AllOptions:
+		return []types.StopOnCommitType{types.Immediate, types.SendProof, types.NextRound}
+	case cons.MinOptions:
+		return []types.StopOnCommitType{types.NextRound}
+	default:
+		panic(optionType)
+	}
+}
+
+// GetCoinTypes returns the types of coins allowed.
+func (MvBinConsRnd2Config) GetCoinTypes(optionType cons.GetOptionType) []types.CoinType {
+	switch optionType {
+	case cons.AllOptions:
+		return types.StrongCoins
+	case cons.MinOptions:
+		return []types.CoinType{types.StrongCoin2Type}
+	default:
+		panic(optionType)
+	}
+}
+
+// GetAllowNoSignatures returns true if the consensus can run without signatures
+func (MvBinConsRnd2Config) GetAllowNoSignatures(gt cons.GetOptionType) []bool { // []types.UseSignaturesType {
+	switch gt {
+	case cons.AllOptions:
+		// return []types.UseSignaturesType{types.ConsDependentSignatures, types.UseSignatures, types.NoSignatures}
+		return types.WithBothBool
+	case cons.MinOptions:
+		// return []types.UseSignaturesType{types.UseSignatures}
+		return types.WithTrue
+	default:
+		panic(gt)
+	}
+}
+
+// GetSigTypes return the types of signatures supported by the consensus
+func (MvBinConsRnd2Config) GetSigTypes(gt cons.GetOptionType) []types.SigType {
+	switch gt {
+	case cons.AllOptions:
+		// return types.CoinSigTypes
+		return types.AllSigTypes // To allow for known coins
+	case cons.MinOptions:
+		return []types.SigType{types.EDCOIN}
+	default:
+		panic(gt)
+	}
+
+}
+
+// GetCollectBroadcast returns the values for if the consensus supports broadcasting the commit message
+// directly to the leader. // TODO for mvbincons2
+func (MvBinConsRnd2Config) GetCollectBroadcast(cons.GetOptionType) []types.CollectBroadcastType {
+	return []types.CollectBroadcastType{types.Full} // TODO
+}
+
+// GetUsePubIndex returns the values for if the consensus supports using pub index or not or both.
+func (MvBinConsRnd2Config) GetUsePubIndexTypes(_ cons.GetOptionType) []bool {
+	return types.WithTrue
+}
+
+// GetRotateCoordTypes returns the values for if the consensus supports rotating coordinator or not or both.
+func (MvBinConsRnd2Config) GetRotateCoordTypes(_ cons.GetOptionType) []bool {
+	return types.WithFalse
+}
+
 func GetConf() cons.ConfigOptions {
 	return MvBinConsRnd1Config{}
 }

--- a/consensus/cons/mvcons3/mv_cons3.go
+++ b/consensus/cons/mvcons3/mv_cons3.go
@@ -178,7 +178,7 @@ func (sc *MvCons3) Start() {
 }
 
 // HasReceivedProposal returns true if the cons has received a valid proposal.
-func (sc *MvCons3) HasReceivedProposal() bool {
+func (sc *MvCons3) HasValidStarted() bool {
 	return len(sc.validatedInitHashes) > 0
 }
 
@@ -566,16 +566,11 @@ func (sc *MvCons3) startCons() error {
 	}
 	// start the init timeout
 	if sc.initTimeOutState == cons.TimeoutNotSent {
-		sc.initTimeOutState = cons.TimeoutSent
-		deser := []*channelinterface.DeserializedItem{
-			{
-				Index:          sc.Index,
-				HeaderType:     messages.HdrMvInitTimeout,
-				IsDeserialized: true,
-				IsLocal:        types.LocalMessage}}
+		// Start the init timer
 		prvIdx, _, _, _ := sc.getMostRecentSupport(false) // TODO better way to decide timeout duration?
-		sc.initTimer = sc.MainChannel.SendToSelf(deser,
-			cons.GetMvTimeout(types.ConsensusRound(sc.Index.Index.(types.ConsensusInt)-prvIdx), sc.ConsItems.MC.MC.GetFaultCount()))
+		sc.initTimer = cons.StartInitTimer(types.ConsensusRound(sc.Index.Index.(types.ConsensusInt)-prvIdx),
+			sc.ConsItems, sc.MainChannel)
+		sc.initTimeOutState = cons.TimeoutSent
 	}
 	return nil
 }

--- a/consensus/cons/rbbcast1/rbbcast1.go
+++ b/consensus/cons/rbbcast1/rbbcast1.go
@@ -93,7 +93,7 @@ func (sc *RbBcast1) PrevHasBeenReset() {
 }
 
 // HasReceivedProposal returns true if the cons has received a valid proposal.
-func (sc *RbBcast1) HasReceivedProposal() bool {
+func (sc *RbBcast1) HasValidStarted() bool {
 	return len(sc.validatedInitHashes) > 0
 }
 

--- a/consensus/cons/simple_cons.go
+++ b/consensus/cons/simple_cons.go
@@ -81,7 +81,7 @@ func (sc *SimpleCons) NeedsConcurrent() types.ConsensusInt {
 }
 
 // HasReceivedProposal panics because SimpleCons has no proposals.
-func (sc *SimpleCons) HasReceivedProposal() bool {
+func (sc *SimpleCons) HasValidStarted() bool {
 	panic("unused")
 }
 

--- a/consensus/cons/test_configs.go
+++ b/consensus/cons/test_configs.go
@@ -254,8 +254,6 @@ func RunRandMCTests(to types.TestOptions, consType types.ConsType, initItem cons
 			toRun = []int{0}
 		}
 
-		to.NumTotalProcs = 20
-		to.RndMemberCount = 10
 		to.LocalRandMemberChange = 5
 		to.EncryptChannels = true
 		to.NoSignatures = true

--- a/consensus/cons/test_configs.go
+++ b/consensus/cons/test_configs.go
@@ -257,6 +257,8 @@ func RunRandMCTests(to types.TestOptions, consType types.ConsType, initItem cons
 		to.NumTotalProcs = 20
 		to.RndMemberCount = 10
 		to.LocalRandMemberChange = 5
+		to.EncryptChannels = true
+		to.NoSignatures = true
 
 		fmt.Println("Running with local random member selection")
 		to.NetworkType = types.RequestForwarder

--- a/consensus/cons/test_funcs.go
+++ b/consensus/cons/test_funcs.go
@@ -1093,10 +1093,9 @@ func RunConsType(initItem consinterface.ConsItem,
 	if err != nil {
 		panic(err)
 	}
-	if !config.PrintMinimum {
-		fmt.Printf("\nRunning test config:\n%s\n", to)
-		// t.Logf("\nRunning generalconfig: %s\n", to)
-	}
+
+	logging.Printf("\nRunning test config:\n%s\n", to)
+	// t.Logf("\nRunning generalconfig: %s\n", to)
 	// make the private keys
 	privKeys, pubKeys := MakeKeys(to)
 	// randItem := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/consensus/cons/test_funcs.go
+++ b/consensus/cons/test_funcs.go
@@ -221,7 +221,7 @@ func GenerateCausalStateMachine(to types.TestOptions, priv sig.Priv, proposer si
 		}
 
 		ret = asset.NewAssetProposer(to.GenRandBytes, config.InitRandBytes, extraParticipantInfo, priv,
-			asset.NewDirectAsset, newAssetFunc, asset.GenDirectAssetTransfer, asset.CheckDirectOutputFunc,
+			asset.NewDirectAsset, newAssetFunc, asset.GenDirectAssetTransfer, asset.CheckDirectOutputFunc, asset.DirectSendToSelf,
 			int(pid) < memberCount, memberCount, priv.GetPub().New, priv.NewSig)
 	case types.ValueAssetProposer:
 		priv = priv.GetBaseKey()
@@ -229,7 +229,7 @@ func GenerateCausalStateMachine(to types.TestOptions, priv sig.Priv, proposer si
 			return asset.NewEmptyAssetTransfer(asset.NewValueAsset, priv.NewSig, priv.GetPub().New)
 		}
 		ret = asset.NewAssetProposer(to.GenRandBytes, config.InitRandBytes, extraParticipantInfo, priv,
-			asset.NewValueAsset, newAssetFunc, asset.GenValueAssetTransfer, asset.CheckValueOutputFunc,
+			asset.NewValueAsset, newAssetFunc, asset.GenValueAssetTransfer, asset.CheckValueOutputFunc, asset.ValueSendToSelf,
 			int(pid) < memberCount, memberCount, priv.GetPub().New, priv.NewSig)
 
 	default:

--- a/consensus/cons/timeouts.go
+++ b/consensus/cons/timeouts.go
@@ -21,6 +21,10 @@ package cons
 
 import (
 	"github.com/tcrain/cons/config"
+	"github.com/tcrain/cons/consensus/channelinterface"
+	"github.com/tcrain/cons/consensus/consinterface"
+	"github.com/tcrain/cons/consensus/messages"
+	"github.com/tcrain/cons/consensus/messagetypes"
 	"github.com/tcrain/cons/consensus/types"
 	"time"
 )
@@ -60,4 +64,31 @@ func GetMvTimeout(round types.ConsensusRound, t int) time.Duration {
 
 	to := time.Duration(round-types.ConsensusRound(t)) * config.MvConsTimeout * time.Millisecond
 	return to
+}
+
+func StartInitTimer(round types.ConsensusRound, item *consinterface.ConsInterfaceItems,
+	cnl channelinterface.MainChannel) channelinterface.TimerInterface {
+
+	// Start the init timer
+	deser := []*channelinterface.DeserializedItem{
+		{
+			Index:          item.ConsItem.GetIndex(),
+			HeaderType:     messages.HdrMvInitTimeout,
+			IsDeserialized: true,
+			Header:         (messagetypes.MvInitMessageTimeout)(round),
+			IsLocal:        types.LocalMessage}}
+	return cnl.SendToSelf(deser, GetMvTimeout(round, item.MC.MC.GetFaultCount()))
+}
+
+func StartEchoTimer(round types.ConsensusRound, item *consinterface.ConsInterfaceItems,
+	cnl channelinterface.MainChannel) channelinterface.TimerInterface {
+	// Start the init timer
+	deser := []*channelinterface.DeserializedItem{
+		{
+			Index:          item.ConsItem.GetIndex(),
+			HeaderType:     messages.HdrMvEchoTimeout,
+			IsDeserialized: true,
+			Header:         (messagetypes.MvEchoMessageTimeout)(round),
+			IsLocal:        types.LocalMessage}}
+	return cnl.SendToSelf(deser, GetMvTimeout(round, item.MC.MC.GetFaultCount()))
 }

--- a/consensus/consgen/genfuncs.go
+++ b/consensus/consgen/genfuncs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tcrain/cons/consensus/cons/binconsrnd4"
 	"github.com/tcrain/cons/consensus/cons/binconsrnd5"
 	"github.com/tcrain/cons/consensus/cons/binconsrnd6"
+	"github.com/tcrain/cons/consensus/cons/mvbinconsrnd2"
 	"github.com/tcrain/cons/consensus/cons/mvcons1"
 	"github.com/tcrain/cons/consensus/cons/mvcons2"
 	"github.com/tcrain/cons/consensus/cons/mvcons3"
@@ -54,10 +55,10 @@ func GetConsItem(to types.TestOptions) (consItem consinterface.ConsItem) {
 		consItem = &binconsrnd5.BinConsRnd5{}
 	case types.BinConsRnd6Type:
 		consItem = &binconsrnd6.BinConsRnd6{}
-	case types.MvBinCons1Type:
+	case types.MvBinCons1Type, types.MvBinConsRnd1Type:
 		consItem = &mvcons1.MvCons1{}
-	case types.MvBinConsRnd1Type:
-		consItem = &mvcons1.MvCons1{}
+	case types.MvBinConsRnd2Type:
+		consItem = &mvbinconsrnd2.MvBinConsRnd2{}
 	case types.MvCons2Type:
 		consItem = &mvcons2.MvCons2{}
 	case types.MvCons3Type:
@@ -93,6 +94,8 @@ func GetConsConfig(to types.TestOptions) (consConfig cons.ConfigOptions) {
 		consConfig = mvcons1.MvBinCons1Config{}
 	case types.MvBinConsRnd1Type:
 		consConfig = mvcons1.MvBinConsRnd1Config{}
+	case types.MvBinConsRnd2Type:
+		consConfig = mvbinconsrnd2.Config{}
 	case types.MvCons2Type:
 		consConfig = mvcons2.MvCons2Config{}
 	case types.MvCons3Type:

--- a/consensus/consinterface/causalconsinterfacestate.go
+++ b/consensus/consinterface/causalconsinterfacestate.go
@@ -453,6 +453,13 @@ func (mcs *CausalConsInterfaceState) GetLastDecidedItem() *ConsInterfaceItems {
 	return mcs.getIndex(mcs.LastDecided)
 }
 
+func (mcs *CausalConsInterfaceState) GetInitItem() (types.ConsensusIndex, *ConsInterfaceItems) {
+	mcs.mutex.Lock()
+	defer mcs.mutex.Unlock()
+
+	return mcs.initSM.GetIndex(), mcs.consItemsMap[mcs.initHash]
+}
+
 func (mcs *CausalConsInterfaceState) GetConsItem(idx types.ConsensusIndex) (ConsItem, error) {
 	if mcs.mainChannel == nil {
 		panic("must set main channel")

--- a/consensus/consinterface/memberchecker/abs_rand_member_checker_test.go
+++ b/consensus/consinterface/memberchecker/abs_rand_member_checker_test.go
@@ -142,7 +142,7 @@ func intTestAbsRandMemberChecker(newPrivFunc func() (sig.Priv, error), newMCFunc
 			memberCount++
 		}
 	}
-	tenPc := int(float64(count) * .1)
+	tenPc := int(float64(count) * .2)
 	// TODO these may fail b/c of random
 	assert.True(t, memberCount <= count/2+2*tenPc)
 	assert.True(t, memberCount >= count/2-2*tenPc)

--- a/consensus/consinterface/messagestate/simple_message_state.go
+++ b/consensus/consinterface/messagestate/simple_message_state.go
@@ -169,8 +169,9 @@ func (sms *SimpleMessageState) GetSigCountMsgID(sm messages.MsgID) int {
 // SetupSignedMessageDuplicates takes a list of headers that are assumed to have the same set of bytes to sign
 // (i.e. the signed part are all the same though they may have different contents following the signed part,
 // for example this is true with partial messages)
-func (sms *SimpleMessageState) SetupSignedMessagesDuplicates(combined *messagetypes.CombinedMessage, hdrs []messages.InternalSignedMsgHeader,
-	mc *consinterface.MemCheckers) (combinedSigned *sig.MultipleSignedMessage, partialsSigned []*sig.MultipleSignedMessage, err error) {
+func (sms *SimpleMessageState) SetupSignedMessagesDuplicates(combined *messagetypes.CombinedMessage,
+	hdrs []messages.InternalSignedMsgHeader, mc *consinterface.MemCheckers) (combinedSigned *sig.MultipleSignedMessage,
+	partialsSigned []*sig.MultipleSignedMessage, err error) {
 
 	if len(hdrs) < 1 {
 		return nil, nil, types.ErrInvalidIndex

--- a/consensus/consinterface/state_machine_interface.go
+++ b/consensus/consinterface/state_machine_interface.go
@@ -66,8 +66,11 @@ type CausalStateMachineInterface interface {
 
 	// HasDecided is called each time a consensus decision takes place, given the index and the decided vaule.
 	// Proposer is the public key of the node that proposed the decision.
-	// It returns a list of causally dependent ids and public keys of the owners of those ids.
-	HasDecided(proposer sig.Pub, index types.ConsensusIndex, decision []byte) []sig.ConsIDPub
+	// Owners are the owners of the input consensus indices.
+	// It returns a list of causally dependent ids and public keys of the owners of those ids,
+	// and the decided value (in case the state machine wants to change it).
+	HasDecided(proposer sig.Pub, index types.ConsensusIndex, owners []sig.Pub,
+		decision []byte) (outputs []sig.ConsIDPub, updatedDecision []byte)
 
 	// CheckDecisions is for testing and will be called at the end of the test with
 	// a causally ordered tree of all the decided values, it should then check if the

--- a/consensus/logging/logging.go
+++ b/consensus/logging/logging.go
@@ -45,12 +45,16 @@ func Printf(format string, args ...interface{}) {
 		// glog.ErrorDepth(1, fmt.Sprintf(format, args))
 		panic("no longer used")
 	case config.GOLOG:
-		err := log.Output(2, fmt.Sprintf(format, args...))
-		if err != nil {
-			panic(err)
+		if !config.PrintMinimum {
+			err := log.Output(2, fmt.Sprintf(format, args...))
+			if err != nil {
+				panic(err)
+			}
 		}
 	case config.FMT:
-		fmt.Printf(format+"\n", args...)
+		if !config.PrintMinimum {
+			fmt.Printf(format, args...)
+		}
 	default:
 		panic("Invalid logging type")
 	}
@@ -63,12 +67,16 @@ func Print(args ...interface{}) {
 		// glog.ErrorDepth(1, args)
 		panic("no longer used")
 	case config.GOLOG:
-		err := log.Output(2, fmt.Sprint(args...))
-		if err != nil {
-			panic(err)
+		if !config.PrintMinimum {
+			err := log.Output(2, fmt.Sprint(args...))
+			if err != nil {
+				panic(err)
+			}
 		}
 	case config.FMT:
-		fmt.Println(args...)
+		if !config.PrintMinimum {
+			fmt.Println(args...)
+		}
 	default:
 		panic("Invalid logging type")
 	}

--- a/consensus/messages/message_ids.go
+++ b/consensus/messages/message_ids.go
@@ -66,9 +66,9 @@ const (
 	HdrEdsig      // An EDDSA signature message
 	HdrEdpub      // An EDDSA public key message
 	HdrSleepPub   // A Sleep pub message
-	HdrSleepSig   // A sleep signature message
 	HdrSleepCoin  // A sleep coin message
 	HdrSchnorrsig // A schnorr signature message
+	HdrSleepSig   // A sleep signature message
 	HdrSchnorrpub // A schnorr public key message
 	HdrBlssig     // A BLS signature message
 	HdrBlspub     // A BLS public key message

--- a/consensus/messages/messages.go
+++ b/consensus/messages/messages.go
@@ -21,7 +21,6 @@ package messages
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/tcrain/cons/consensus/types"
 )
 
@@ -230,7 +229,7 @@ func (m *Message) ComputeHash(offset, endoffset int, includeHash bool) (types.Ha
 	return hash, l, nil
 }
 
-var ErrInvalidHash = fmt.Errorf("Invalid hash")
+// var ErrInvalidHash = fmt.Errorf("Invalid hash")
 
 func (m *Message) CheckHash(offset int, endoffset int, includesHash bool) (types.HashBytes, int, error) {
 	var hsh []byte
@@ -250,7 +249,7 @@ func (m *Message) CheckHash(offset int, endoffset int, includesHash bool) (types
 	check := types.GetHash(buff)
 	if includesHash {
 		if !bytes.Equal(hsh, check) {
-			return nil, 0, ErrInvalidHash
+			return nil, 0, types.ErrInvalidHash
 		}
 	}
 	return check, hashLen, nil

--- a/consensus/messagetypes/hash_msg.go
+++ b/consensus/messagetypes/hash_msg.go
@@ -60,7 +60,7 @@ func (hm *HashMessage) GetMsgID() messages.MsgID {
 func (hm *HashMessage) SerializeInternal(m *messages.Message) (bytesWritten, signEndOffset int, err error) {
 	// Now the proposal hash
 	if len(hm.TheHash) != types.GetHashLen() {
-		err = messages.ErrInvalidHash
+		err = types.ErrInvalidHash
 		return
 	}
 	v, signEndOffset := (*messages.MsgBuffer)(m).AddBytes(hm.TheHash)

--- a/consensus/messagetypes/messages_test.go
+++ b/consensus/messagetypes/messages_test.go
@@ -175,7 +175,7 @@ func TestCreateBadMsg3(t *testing.T) {
 		t.Error("Got invalid msg type", ht, tstMsg.GetID())
 	}
 	_, err = tstMsg.Deserialize(msg, types.IntIndexFuns)
-	if err != messages.ErrInvalidHash {
+	if err != types.ErrInvalidHash {
 		t.Error("Should have failed hash check deserialization")
 	}
 

--- a/consensus/messagetypes/mv_commit_msg.go
+++ b/consensus/messagetypes/mv_commit_msg.go
@@ -60,7 +60,7 @@ func (mvc *MvCommitMessage) GetMsgID() messages.MsgID {
 func (mvc *MvCommitMessage) SerializeInternal(m *messages.Message) (bytesWritten, signEndOffset int, err error) {
 	// Now the proposal hash
 	if len(mvc.ProposalHash) != types.GetHashLen() {
-		err = messages.ErrInvalidHash
+		err = types.ErrInvalidHash
 		return
 	}
 	v, _ := (*messages.MsgBuffer)(m).AddBytes(mvc.ProposalHash)

--- a/consensus/messagetypes/mv_echo_msg.go
+++ b/consensus/messagetypes/mv_echo_msg.go
@@ -60,7 +60,7 @@ func (mve *MvEchoMessage) GetMsgID() messages.MsgID {
 func (mve *MvEchoMessage) SerializeInternal(m *messages.Message) (bytesWritten, signEndOffset int, err error) {
 	// Now the proposal hash
 	if len(mve.ProposalHash) != types.GetHashLen() {
-		err = messages.ErrInvalidHash
+		err = types.ErrInvalidHash
 		return
 	}
 	v, _ := (*messages.MsgBuffer)(m).AddBytes(mve.ProposalHash)

--- a/consensus/messagetypes/mv_recover_message.go
+++ b/consensus/messagetypes/mv_recover_message.go
@@ -53,7 +53,7 @@ func (mrm *MvRequestRecoverMessage) Serialize(m *messages.Message) (int, error) 
 
 	// Now the proposal hash
 	if len(mrm.ProposalHash) != types.GetHashLen() {
-		return 0, messages.ErrInvalidHash
+		return 0, types.ErrInvalidHash
 	}
 	l1, _ := (*messages.MsgBuffer)(m).AddBytes(mrm.ProposalHash)
 	if l1 != len(mrm.ProposalHash) {

--- a/consensus/rpcsetup/test_funcs.go
+++ b/consensus/rpcsetup/test_funcs.go
@@ -387,7 +387,7 @@ func runInitialSetup(setup *SingleConsSetup, t assert.TestingT) (err error) {
 	scs.Gc = consinterface.CreateGeneralConfig(scs.I, eis, scs.Stats, scs.To,
 		preHeader, scs.PrivKey)
 
-	fmt.Printf("Running cons %T with state machine %v\n", scs.Sc, scs.To.StateMachineType)
+	logging.Printf("Running cons %T with state machine %v\n", scs.Sc, scs.To.StateMachineType)
 
 	// Open storage
 	scs.Ds = cons.OpenTestStore(scs.To.StorageBuffer, scs.To.StorageType, cons.GetStoreType(scs.To),

--- a/consensus/statemachine/asset/asset_proposer.go
+++ b/consensus/statemachine/asset/asset_proposer.go
@@ -255,7 +255,7 @@ func (da *AssetProposer) HasDecided(proposer sig.Pub, index types.ConsensusIndex
 	}
 	var end bool // true when the test is over
 	if len(decision) == 0 {
-		fmt.Println("DECIDED NIL", da.myProposalCount, da.myKey.GetPub())
+		logging.Info("DECIDED NIL", da.myProposalCount, da.myKey.GetPub())
 		items := make([]types.HashBytes, 1+len(index.AdditionalIndices))
 		for i, nxt := range append([]types.ConsensusID{index.FirstIndex}, index.AdditionalIndices...) {
 			b, err := nxt.MarshalBinary()

--- a/consensus/statemachine/asset/asset_transfer.go
+++ b/consensus/statemachine/asset/asset_transfer.go
@@ -199,6 +199,14 @@ func (at *AssetTransfer) Encode(writer io.Writer) (n int, err error) {
 			return
 		}
 	}
+
+	// be sure we have encoded the signed part
+	if at.SignedBytes == nil {
+		if err = at.encodeSignedBytes(); err != nil {
+			return
+		}
+	}
+
 	var nxtN int
 	// First the size of the signed part
 	nxtN, err = utils.EncodeUvarint(uint64(len(at.SignedBytes)), writer)

--- a/consensus/statemachine/asset/direct_asset.go
+++ b/consensus/statemachine/asset/direct_asset.go
@@ -65,7 +65,7 @@ func GenDirectAssetTransfer(priv sig.Priv, participants []sig.Pub, table *Accoun
 	for i := range acc.Assets[:1] {
 		recipiants[i] = priv.GetPub()
 	}
-	_, outputs := GenDirectAssetOutput(acc, acc.Assets)
+	_, outputs := GenDirectAssetOutput(acc, acc.Assets[:1])
 	tr, err = table.GenerateAssetTransfer(priv, inputs, outputs, recipiants, CheckDirectOutputFunc)
 	if err != nil {
 		panic(err)
@@ -98,4 +98,13 @@ func CheckDirectOutputFunc(account *AssetAccount, inputs []AssetInterface, outpu
 		}
 	}
 	return nil
+}
+
+// DirectSendToSelf returns the inputs as outputs with new hashes.
+func DirectSendToSelf(account *AssetAccount, inputs []AssetInterface) (outputs []AssetInterface) {
+	outputs = make([]AssetInterface, len(inputs))
+	for i, nxt := range inputs {
+		outputs[i] = &DirectAsset{BasicAsset: *NewBasicAsset(types.GetHash(nxt.GetID()))}
+	}
+	return
 }

--- a/consensus/statemachine/asset/types.go
+++ b/consensus/statemachine/asset/types.go
@@ -27,6 +27,9 @@ import (
 // CheckTransferOutputFunc is used to check if the given asset inputs and outputs for a transfer are valid.
 type CheckTransferOutputFunc func(account *AssetAccount, inputs []AssetInterface, outputs []AssetInterface) error
 
+// SendToSelfAsset is used when a nil value is decided, so the asset should just be sent back to the owner with a new ID
+type SendToSelfAsset func(account *AssetAccount, inputs []AssetInterface) []AssetInterface
+
 // GenAssetTransferFunc is called during the experiment each time a new transfer asset is needed.
 // It returns nil if there is no assets to transfer.
 type GenAssetTransferFunc func(priv sig.Priv, participants []sig.Pub, table *AccountTable) (tr *AssetTransfer)

--- a/consensus/types/coins.go
+++ b/consensus/types/coins.go
@@ -46,7 +46,8 @@ type CoinType int
 
 const (
 	NoCoinType          CoinType = iota
-	KnownCoinType                // predefined coins
+	KnownCoinType                // predefined coins (predictable random)
+	FlipCoinType                 // predefined coins, flips from 1 to 0
 	LocalCoinType                // each process chooses a random local coin
 	StrongCoin1Type              // a strong coin implemented by an n-t (or t+1) threshold signature
 	StrongCoin1EchoType          // StrongCoin1 with an extra message step (allows use of t+1 coin)
@@ -63,7 +64,7 @@ func CheckStrongCoin(coinType CoinType) bool {
 	return false
 }
 
-var StrongCoins = []CoinType{StrongCoin1Type, StrongCoin1EchoType, StrongCoin2Type, StrongCoin2EchoType, KnownCoinType}
+var StrongCoins = []CoinType{StrongCoin1Type, StrongCoin1EchoType, StrongCoin2Type, StrongCoin2EchoType, KnownCoinType, FlipCoinType}
 var WeakCoins = []CoinType{LocalCoinType}
 var AllCoins = append(StrongCoins, WeakCoins...) // append([]CoinType{NoCoinType}, append(StrongCoins, WeakCoins...)...)
 
@@ -79,6 +80,8 @@ func (ct CoinType) String() string {
 		return "StrongCoin2"
 	case LocalCoinType:
 		return "LocalCoin"
+	case FlipCoinType:
+		return "FlipCoin"
 	case StrongCoin2EchoType:
 		return "StrongCoin2Echo"
 	case KnownCoinType:

--- a/consensus/types/consensus.go
+++ b/consensus/types/consensus.go
@@ -337,6 +337,7 @@ const (
 	BinConsRnd6Type                   // Randomized binary consensus combination of BinConsRnd2 and BinConsRnd4
 	MvBinCons1Type                    // Multivalue reduction to binary consensus BinCons1
 	MvBinConsRnd1Type                 // Multivalue reduction to binary consensus BinConsRnd1
+	MvBinConsRnd2Type                 // Multivalue reduction to binary consensus BinConsRnd2
 	MvCons2Type                       // Multivalue PBFT like
 	MvCons3Type                       // Multivalue HotStuff like
 	RbBcast1Type                      // Reliable broadcast like
@@ -366,6 +367,8 @@ func (ct ConsType) String() string {
 		return "MvBinCons1"
 	case MvBinConsRnd1Type:
 		return "MvBinConsRnd1"
+	case MvBinConsRnd2Type:
+		return "MvBinConsRnd2"
 	case MvCons2Type:
 		return "MvCons2"
 	case MvCons3Type:

--- a/consensus/utils/types.go
+++ b/consensus/utils/types.go
@@ -22,6 +22,7 @@ package utils
 type StringNode struct {
 	Value    string
 	Children SortedChildren
+	Other    interface{}
 }
 
 type SortedChildren []*StringNode

--- a/scripts/runrpc.sh
+++ b/scripts/runrpc.sh
@@ -1,5 +1,5 @@
-./preg &
-./rpcnode &
+PRINT_MIN=true ./preg &
+PRINT_MIN=true ./rpcnode &
 
 #go run -race ./cmd/preg/preg.go &
 #go run -race ./cmd/rpcnode/rpcnode.go &

--- a/testconfigs/bls_multi_p2p.json
+++ b/testconfigs/bls_multi_p2p.json
@@ -1,5 +1,5 @@
 {
-    "TestID": 3,
+    "TestID": 1,
     "MaxRounds": 10,
     "NumTotalProcs": 40,
     "NetworkType": 1,

--- a/testconfigs/coin_all2all.json
+++ b/testconfigs/coin_all2all.json
@@ -1,7 +1,7 @@
 {
-    "TestID": 3,
+    "TestID": 2,
     "ConsType": 2,
-    "CoinType": 5,
+    "CoinType": 6,
     "EncryptChannels": true,
     "NoSignatures": true,
     "MaxRounds": 10,

--- a/testconfigs/ec_all2all.json
+++ b/testconfigs/ec_all2all.json
@@ -1,5 +1,5 @@
 {
-    "TestID": 1,
+    "TestID": 3,
     "MaxRounds": 10,
     "NumTotalProcs": 8,
     "NetworkType": 0,

--- a/testconfigs/ecvrf_p2p.json
+++ b/testconfigs/ecvrf_p2p.json
@@ -1,6 +1,6 @@
 {
-    "TestID": 3,
-    "ConsType": 9,
+    "TestID": 4,
+    "ConsType": 10,
     "StateMachineType": 1,
     "MaxRounds": 10,
     "NumTotalProcs": 40,

--- a/testconfigs/requestcausal_p2p.json
+++ b/testconfigs/requestcausal_p2p.json
@@ -1,9 +1,10 @@
 {
-    "TestID": 3,
+    "TestID": 6,
     "OrderingType": 1,
-    "ConsType": 12,
+    "ConsType": 9,
     "StateMachineType": 6,
     "MaxRounds": 10,
+    "CoinType": 2,
     "NumTotalProcs": 25,
     "RndMemberCount": 10,
     "GenRandBytes": false,

--- a/testconfigs/requestcons_p2p.json
+++ b/testconfigs/requestcons_p2p.json
@@ -1,5 +1,5 @@
 {
-    "TestID": 5,
+    "TestID": 7,
     "ConsType": 13,
     "StateMachineType": 1,
     "MaxRounds": 10,

--- a/testconfigs/thrsh_all2all.json
+++ b/testconfigs/thrsh_all2all.json
@@ -1,7 +1,7 @@
 {
-    "TestID": 2,
+    "TestID": 8,
     "ConsType": 1,
-    "CoinType": 3,
+    "CoinType": 4,
     "MaxRounds": 10,
     "NumTotalProcs": 8,
     "NetworkType": 0,


### PR DESCRIPTION
Add a coordinator based binary to multi-value reduction using BinConsRnd2.
It does not needs signatures and is compatible with the local random member selection types, but note that for this it is not randomized because it must use a pre-known coin (so it is not live in asynchrony).